### PR TITLE
Update invited talks with new details

### DIFF
--- a/_includes/sections/talks.html
+++ b/_includes/sections/talks.html
@@ -14,7 +14,8 @@
 
   <div class="col-lg-8 col-lg-offset-2 m-t-lg m-b-lg wow zoomIn">
     <ul>
-        <li><b>2026.2:</b> Invited talk at the RTX Research Center to present <a href="https://openreview.net/forum?id=a9dngZLqGS">FROST</a>. </li>
+        <li><b>2026.4:</b> Invited talk at the Northwestern CS Department to present <a href="https://www.bing.com/search?qs=HS&pq=hao&sk=CSYN1UAS5MT3LS6CT2AS2HS2&sc=24-3&q=haozheng+luo&cvid=a89a713ba8fe48e596d31cb5993d8bf6&gs_lcrp=EgRlZGdlKgYIAhBFGDsyBwgAEAAY-QcyBggBEAAYQDIGCAIQRRg7MgYIAxBFGDkyBggEEEUYQTIGCAUQRRg9MgYIBhBFGD0yBggHEEUYQTIGCAgQRRg80gEIMjA4NWowajSoAgiwAgE&PC=U531&FPIG=CA7CD2F315024869AF11BA08A5D52727&first=11&FORM=PERE">$\mathrm{Softmax}_1$ is All You Need</a>. </li>
+        <li><b>2026.3:</b> Invited talk at the RTX Research Center to present <a href="https://openreview.net/forum?id=a9dngZLqGS">FROST</a>. </li>
         <li><b>2026.2:</b> Invited talk at the Wisemodel to present <a href="https://docs.google.com/presentation/d/1fWqLPHWaW1ehaHS6aLWExyp1Y0QmuBXRHHonxEsjqfw/edit?usp=sharingS">$\mathrm{Softmax}_1$ is All You Need</a>. </li>
         <li><b>2025.11:</b> Invited talk at the Northwestern University CS450 to present <a href="https://www.usenix.org/conference/usenixsecurity25/presentation/yu-jiahao">BOOST</a>. </li>
         <li><b>2025.10:</b> Invited talk at the Northwestern University AI Safety Club to present <a href="https://www.usenix.org/conference/usenixsecurity25/presentation/yu-jiahao">BOOST</a>. </li>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk content-only change to a static HTML include; main risk is incorrect/unstable external links or dates displayed on the site.
> 
> **Overview**
> Updates the `Talks` section to add a new **2026.4** invited talk entry (Northwestern CS) and shifts the RTX Research Center `FROST` talk date from **2026.2** to **2026.3**, keeping the list in chronological order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91786888780a61594a6a6abe54402136adda1abd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->